### PR TITLE
wrote a little wrapper script for honcho that works with anything run…

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,5 @@
 api: python app.py
 queue: rq worker
 web: ngrok http -subdomain $NGROK_HOSTNAME 5000
+neo4j: scripts/honcho_service_check.bash neo4j
+redis: scripts/honcho_service_check.bash redis

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests
 twilio
 neomodel
 honcho
+python-dotenv

--- a/scripts/honcho_service_check.bash
+++ b/scripts/honcho_service_check.bash
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+service=${1}
+[[ -z "${service}" ]] && echo "Usage: $0 <service name>" && exit 1
+
+# Don't spam the honcho output. Only display the first time through
+show_text=0
+while [ 1 ]; do
+
+  if brew services list | grep "${service}" | grep -i "start" | grep -v grep >/dev/null 2>&1; then
+    [[ ${show_text} -eq 0 ]] && echo "brew services list for ${service} is running."
+    pid_of=$(launchctl list | grep "${service}" | grep -v grep | awk '{ print $1 }')
+    if [[ -n "${pid_of}" ]] && ps ${pid_of} >/dev/null 2>&1; then
+      [[ ${show_text} -eq 0 ]] && echo "ps shows ${service} is running. PID: ${pid_of}"
+    else
+      # Display the exit text otherwise honcho just stops quietly
+      echo "ps shows ${service} as not running."
+      break
+    fi
+  else
+    echo "brew services list for ${service} is not running."
+    break
+  fi
+
+  sleep 5
+
+  # avoid spamming output starting the second time through
+  show_text=1
+
+done


### PR DESCRIPTION
… via homebrew + launchctl. This way you can require something you dont' necessarily want honcho to manage but you want to require it be running. Added python-dotenv - any k=>v pair added to the .env file will be available to os.environ.{get,set}.